### PR TITLE
Module lambda_function_basicを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ format: \
 
 fmt-terraform: \
 	fmt-terraform-root \
-	fmt-terraform-common
+	fmt-terraform-common \
+	fmt-terraform-lambda-function-basic
 
 fmt-terraform-root:
 	terraform fmt
@@ -14,8 +15,13 @@ fmt-terraform-common:
 	cd terraform_modules/common && \
 	terraform fmt
 
+fmt-terraform-lambda-function-basic:
+	cd terraform_modules/lambda_function_basic && \
+	terraform fmt
+
 .PHONY: \
 	format \
 	fmt-terraform \
 	fmt-terraform-root \
-	fmt-terraform-common
+	fmt-terraform-common \
+	fmt-terraform-lambda-function-basic

--- a/src/handlers/tmp_001/index.py
+++ b/src/handlers/tmp_001/index.py
@@ -1,0 +1,3 @@
+def handler(event, context):
+    print('test')
+    return "success"

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,9 +2,35 @@ terraform {
   backend "s3" {
     bucket = "luciferous-hidemy-name-prox-bucketterraformstates-1r2mrb5ix8t4q"
     key    = "cloud/state.tfstate"
+    region = "ap-northeast-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.33"
+    }
+  }
+}
+
+provider "aws" {
+  region = local.region
+
+  default_tags {
+    tags = {
+      SystemName = local.system_name
+    }
   }
 }
 
 module "common" {
   source = "./terraform_modules/common"
+
+  system_name = local.system_name
+  region      = local.region
+}
+
+locals {
+  region      = "ap-northeast-1"
+  system_name = "hidemy-name-proxy-cloud"
 }

--- a/terraform_modules/common/iam.tf
+++ b/terraform_modules/common/iam.tf
@@ -1,0 +1,21 @@
+data "aws_iam_policy_document" "assume_role_policy_lambda" {
+  policy_id = "assume_role_policy_lambda"
+  statement {
+    sid     = "LambdaAssumeRolePolicy"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["lambda.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "tmp" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy_lambda.json
+}
+
+resource "aws_iam_role_policy_attachment" "tmp_basic" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.tmp.name
+}

--- a/terraform_modules/common/lambda.tf
+++ b/terraform_modules/common/lambda.tf
@@ -1,0 +1,11 @@
+module "tmp_001" {
+  source = "../lambda_function_basic"
+
+  function_identifier = "tmp_001"
+  handler             = "index.handler"
+  memory_size         = 128
+
+  system_name = var.system_name
+  role_arn    = aws_iam_role.tmp.arn
+  region      = var.region
+}

--- a/terraform_modules/common/sns.tf
+++ b/terraform_modules/common/sns.tf
@@ -1,0 +1,1 @@
+resource "aws_sns_topic" "tmp" {}

--- a/terraform_modules/common/terraform_config.tf
+++ b/terraform_modules/common/terraform_config.tf
@@ -6,5 +6,3 @@ terraform {
     }
   }
 }
-
-resource "aws_sns_topic" "tmp" {}

--- a/terraform_modules/common/variables.tf
+++ b/terraform_modules/common/variables.tf
@@ -1,0 +1,9 @@
+variable "system_name" {
+  type     = string
+  nullable = false
+}
+
+variable "region" {
+  type     = string
+  nullable = false
+}

--- a/terraform_modules/lambda_function_basic/lambda.tf
+++ b/terraform_modules/lambda_function_basic/lambda.tf
@@ -1,0 +1,33 @@
+data "archive_file" "package" {
+  type        = "zip"
+  output_path = "function_${var.function_identifier}.zip"
+  source_dir  = "${path.root}/src/handlers/${var.function_identifier}"
+}
+
+resource "aws_lambda_function" "function" {
+  function_name    = replace("${var.system_name}-${var.function_identifier}", "_", "-")
+  role             = var.role_arn
+  runtime          = var.runtime
+  architectures    = ["arm64"]
+  handler          = var.handler
+  memory_size      = var.memory_size
+  timeout          = var.timeout
+  filename         = data.archive_file.package.output_path
+  source_code_hash = data.archive_file.package.output_base64sha256
+  publish          = true
+
+  layers = concat(var.layers, [
+    # Powertools for AWS Lambda (Python) [arm64] with extra dependencies version 2.32.0
+    "arn:aws:lambda:${var.region}:017000801446:layer:AWSLambdaPowertoolsPythonV2-Arm64:60"
+  ])
+
+  environment {
+    variables = var.environment_variables
+  }
+}
+
+resource "aws_lambda_alias" "function" {
+  function_name    = aws_lambda_function.function.function_name
+  function_version = aws_lambda_function.function.version
+  name             = var.alias
+}

--- a/terraform_modules/lambda_function_basic/log.tf
+++ b/terraform_modules/lambda_function_basic/log.tf
@@ -1,0 +1,3 @@
+resource "aws_cloudwatch_log_group" "function" {
+  name = "/aws/lambda/${aws_lambda_function.function.function_name}"
+}

--- a/terraform_modules/lambda_function_basic/outputs.tf
+++ b/terraform_modules/lambda_function_basic/outputs.tf
@@ -1,0 +1,23 @@
+output "function_name" {
+  value = aws_lambda_function.function.function_name
+}
+
+output "function_arn" {
+  value = aws_lambda_function.function.arn
+}
+
+output "function_alias_name" {
+  value = aws_lambda_alias.function.name
+}
+
+output "function_alias_arn" {
+  value = aws_lambda_alias.function.arn
+}
+
+output "log_group_name" {
+  value = aws_cloudwatch_log_group.function.name
+}
+
+output "log_group_arn" {
+  value = aws_cloudwatch_log_group.function.arn
+}

--- a/terraform_modules/lambda_function_basic/terraform_config.tf
+++ b/terraform_modules/lambda_function_basic/terraform_config.tf
@@ -1,0 +1,1 @@
+../common/terraform_config.tf

--- a/terraform_modules/lambda_function_basic/variables.tf
+++ b/terraform_modules/lambda_function_basic/variables.tf
@@ -1,0 +1,60 @@
+variable "function_identifier" {
+  type     = string
+  nullable = false
+}
+
+variable "system_name" {
+  type     = string
+  nullable = false
+}
+
+variable "role_arn" {
+  type     = string
+  nullable = false
+}
+
+variable "runtime" {
+  type     = string
+  nullable = false
+  default  = "python3.12"
+}
+
+variable "handler" {
+  type     = string
+  nullable = false
+}
+
+variable "memory_size" {
+  type     = number
+  nullable = false
+  default  = 256
+}
+
+variable "timeout" {
+  type     = number
+  nullable = false
+  default  = 120
+}
+
+variable "layers" {
+  type     = list(string)
+  nullable = false
+  default  = []
+}
+
+variable "region" {
+  type     = string
+  nullable = false
+}
+
+variable "environment_variables" {
+  type     = map(string)
+  nullable = false
+  default  = {}
+}
+
+variable "alias" {
+  type     = string
+  nullable = false
+  default  = "alias"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- AWS Lambda関数の基本設定とそのエイリアスの作成機能を追加しました。
	- AWS SNSトピック「tmp」の作成機能を追加しました。
	- AWS Lambda関数用のIAMロールと基本実行ポリシーの定義機能を追加しました。
	- Terraformのフォーマットを行う新しいMakefileターゲットを追加しました。
- **改善点**
	- `terraform.tf`ファイルに`region`属性、`required_providers`ブロック、`default_tags`の設定、`module "common"`ブロックの更新を含む改善を行いました。
	- Terraformモジュール`lambda_function_basic`の出力定義を追加しました。
- **バグ修正**
	- `terraform_config.tf`ファイルから不要な`aws_sns_topic`リソース宣言を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->